### PR TITLE
fix: T22428: preparation for upgrade to Jena 5

### DIFF
--- a/semanticz-connector-fuseki/src/main/java/zone/cogni/semanticz/connectors/fuseki/FusekiSparqlService.java
+++ b/semanticz-connector-fuseki/src/main/java/zone/cogni/semanticz/connectors/fuseki/FusekiSparqlService.java
@@ -19,7 +19,6 @@
 
 package zone.cogni.semanticz.connectors.fuseki;
 
-import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionBuilder;
 import org.apache.jena.query.ResultSet;
@@ -42,6 +41,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
+import static zone.cogni.semanticz.connectors.utils.Constants.CONTENT_TYPE;
 import static zone.cogni.semanticz.connectors.utils.HttpClientUtils.execute;
 
 /**

--- a/semanticz-connector-fuseki/src/main/java/zone/cogni/semanticz/connectors/fuseki/FusekiSparqlService.java
+++ b/semanticz-connector-fuseki/src/main/java/zone/cogni/semanticz/connectors/fuseki/FusekiSparqlService.java
@@ -19,7 +19,7 @@
 
 package zone.cogni.semanticz.connectors.fuseki;
 
-import org.apache.http.HttpHeaders;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionBuilder;
 import org.apache.jena.query.ResultSet;
@@ -75,7 +75,7 @@ public class FusekiSparqlService implements SparqlService {
       request = HttpRequest
           .newBuilder(URI.create(sparqlUrl))
           .POST(BodyPublishers.ofFile(file.toPath()))
-          .header(HttpHeaders.CONTENT_TYPE, config.getTurtleMimeType() + ";charset=utf-8")
+          .header(CONTENT_TYPE, config.getTurtleMimeType() + ";charset=utf-8")
           .build();
     } catch (FileNotFoundException e) {
       throw new RuntimeException(e);
@@ -96,7 +96,7 @@ public class FusekiSparqlService implements SparqlService {
         .newBuilder(URI.create(config.getUpdateUrl()))
         .POST(BodyPublishers.ofString("update=" + URLEncoder.encode(updateQuery,
                 StandardCharsets.UTF_8)))
-        .header(HttpHeaders.CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
+        .header(CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
         .build();
     System.out.println(request);
     execute(request, httpClient);
@@ -120,7 +120,7 @@ public class FusekiSparqlService implements SparqlService {
     final BodyPublisher p = BodyPublishers.ofByteArray(writer.toString().getBytes());
     final HttpRequest.Builder builder = HttpRequest
         .newBuilder(URI.create(insertUrl))
-        .header(HttpHeaders.CONTENT_TYPE, config.getTurtleMimeType() + ";charset=utf-8");
+        .header(CONTENT_TYPE, config.getTurtleMimeType() + ";charset=utf-8");
 
     final HttpRequest request = (replace ? builder.PUT(p) : builder.POST(p)).build();
     execute(request, httpClient);

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
@@ -20,7 +20,6 @@
 package zone.cogni.semanticz.connectors.graphdb;
 
 import org.apache.commons.io.FileUtils;
-import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionBuilder;
 import org.apache.jena.query.ResultSet;
@@ -42,6 +41,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
 
+import static zone.cogni.semanticz.connectors.utils.Constants.CONTENT_TYPE;
 import static zone.cogni.semanticz.connectors.utils.HttpClientUtils.execute;
 
 public class GraphDBSparqlService implements SparqlService {

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
@@ -20,7 +20,7 @@
 package zone.cogni.semanticz.connectors.graphdb;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.http.HttpHeaders;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionBuilder;
 import org.apache.jena.query.ResultSet;
@@ -81,7 +81,7 @@ public class GraphDBSparqlService implements SparqlService {
     final HttpRequest request = HttpRequest
         .newBuilder()
         .POST(BodyPublishers.ofString(ttl, StandardCharsets.UTF_8))
-        .header(HttpHeaders.CONTENT_TYPE, Lang.TURTLE.getHeaderString())
+        .header(CONTENT_TYPE, Lang.TURTLE.getHeaderString())
         .uri(URI.create(config.getSparqlUpdateEndpoint()+"?context=" + URLEncoder.encode("<"+graphUri+">", StandardCharsets.UTF_8)))
         .build();
     execute(request, httpClient);
@@ -99,7 +99,7 @@ public class GraphDBSparqlService implements SparqlService {
     final HttpRequest request = HttpRequest
         .newBuilder(URI.create(config.getSparqlUpdateEndpoint()))
         .POST(BodyPublishers.ofString("update=" + URLEncoder.encode(updateQuery, StandardCharsets.UTF_8), StandardCharsets.UTF_8))
-        .header(HttpHeaders.CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
+        .header(CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
         .build();
     execute(request, httpClient);
   }

--- a/semanticz-connector-stardog/src/main/java/zone/cogni/semanticz/connectors/stardog/StardogSparqlService.java
+++ b/semanticz-connector-stardog/src/main/java/zone/cogni/semanticz/connectors/stardog/StardogSparqlService.java
@@ -19,7 +19,6 @@
 
 package zone.cogni.semanticz.connectors.stardog;
 
-import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionBuilder;
 import org.apache.jena.query.ResultSet;
@@ -42,6 +41,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublisher;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Function;
+
+import static zone.cogni.semanticz.connectors.utils.Constants.CONTENT_TYPE;
 
 public class StardogSparqlService implements SparqlService {
   private final String endpointUrl;

--- a/semanticz-connector-stardog/src/main/java/zone/cogni/semanticz/connectors/stardog/StardogSparqlService.java
+++ b/semanticz-connector-stardog/src/main/java/zone/cogni/semanticz/connectors/stardog/StardogSparqlService.java
@@ -19,7 +19,7 @@
 
 package zone.cogni.semanticz.connectors.stardog;
 
-import org.apache.http.HttpHeaders;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionBuilder;
 import org.apache.jena.query.ResultSet;
@@ -63,7 +63,7 @@ public class StardogSparqlService implements SparqlService {
       request = HttpRequest
           .newBuilder(URI.create(endpointUrl))
           .POST(HttpRequest.BodyPublishers.ofFile(file.toPath()))
-          .header(HttpHeaders.CONTENT_TYPE, Lang.TURTLE.getHeaderString()+";charset=utf-8")
+          .header(CONTENT_TYPE, Lang.TURTLE.getHeaderString()+";charset=utf-8")
           .build();
     } catch (FileNotFoundException e) {
       throw new RuntimeException(e);
@@ -85,7 +85,7 @@ public class StardogSparqlService implements SparqlService {
     final HttpRequest request = HttpRequest
         .newBuilder(URI.create(endpointUrl + "/update"))
         .POST(HttpRequest.BodyPublishers.ofString("update=" + URLEncoder.encode(updateQuery, StandardCharsets.UTF_8), StandardCharsets.UTF_8))
-        .header(HttpHeaders.CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
+        .header(CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
         .build();
     HttpClientUtils.execute(request, httpClient);
   }
@@ -113,7 +113,7 @@ public class StardogSparqlService implements SparqlService {
     String graphStoreUrl = endpointUrl + "?graph=" + URLEncoder.encode(graphUri, StandardCharsets.UTF_8);
     byte[] body = JenaUtils.toByteArray(model, TripleSerializationFormat.turtle);
     final HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(graphStoreUrl))
-        .header(HttpHeaders.CONTENT_TYPE, Lang.TURTLE.getHeaderString() + ";charset=utf-8");
+        .header(CONTENT_TYPE, Lang.TURTLE.getHeaderString() + ";charset=utf-8");
     final BodyPublisher p = HttpRequest.BodyPublishers.ofByteArray(body);
     final HttpRequest request = (replace ? builder.PUT(p) : builder.POST(p)).build();
     HttpClientUtils.execute(request, httpClient);

--- a/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/utils/ApacheHttpClientUtils.java
+++ b/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/utils/ApacheHttpClientUtils.java
@@ -49,6 +49,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static zone.cogni.semanticz.connectors.utils.Constants.APPLICATION_SPARQL_QUERY;
+
 /**
  * Utility functions for working with the Apache HttpClient.
  */
@@ -114,7 +117,7 @@ public class ApacheHttpClientUtils {
    * @return ResultSet language (XML/JSON)
    */
   private static Lang getResultSetLanguage(final HttpResponse response, final String acceptHeader) {
-    String actualContentType = response.getFirstHeader(HttpHeaders.CONTENT_TYPE).getValue();
+    String actualContentType = response.getFirstHeader(CONTENT_TYPE).getValue();
     actualContentType = removeCharset(actualContentType);
 
     // If the server fails to return a Content-Type then we will assume
@@ -141,7 +144,7 @@ public class ApacheHttpClientUtils {
   private static HttpPost createPost(final String sparqlServiceUrl, final String acceptHeader,
       final String username, final String password, final boolean addBasicAuth) {
     final HttpPost httpPost = new HttpPost(sparqlServiceUrl);
-    httpPost.setHeader(HttpHeaders.CONTENT_TYPE, "application/sparql-query");
+    httpPost.setHeader(CONTENT_TYPE, APPLICATION_SPARQL_QUERY);
     httpPost.setHeader(HttpHeaders.ACCEPT, acceptHeader);
     if (addBasicAuth) {
       httpPost.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.encodeBase64String(
@@ -168,7 +171,7 @@ public class ApacheHttpClientUtils {
     try (final CloseableHttpClient httpclient = ApacheHttpClientUtils.buildHttpClient(username,
         password)) {
       final HttpEntityEnclosingRequestBase httpPost = put ? new HttpPut(url) : new HttpPost(url);
-      httpPost.setHeader(HttpHeaders.CONTENT_TYPE, contentType);
+      httpPost.setHeader(CONTENT_TYPE, contentType);
       if (addBasicAuth) {
         httpPost.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.encodeBase64String(
             (username + ":" + password).getBytes(StandardCharsets.UTF_8)));

--- a/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/utils/ApacheHttpClientUtils.java
+++ b/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/utils/ApacheHttpClientUtils.java
@@ -49,8 +49,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
-import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 import static zone.cogni.semanticz.connectors.utils.Constants.APPLICATION_SPARQL_QUERY;
+import static zone.cogni.semanticz.connectors.utils.Constants.CONTENT_TYPE;
 
 /**
  * Utility functions for working with the Apache HttpClient.

--- a/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/virtuoso/VirtuosoApacheHttpClientRdfStoreService.java
+++ b/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/virtuoso/VirtuosoApacheHttpClientRdfStoreService.java
@@ -56,7 +56,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static zone.cogni.semanticz.connectors.utils.Constants.CONTENT_TYPE;
 import static zone.cogni.semanticz.connectors.utils.Constants.TEXT_TURTLE;
 
 /**

--- a/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/virtuoso/VirtuosoApacheHttpClientRdfStoreService.java
+++ b/semanticz-connector-virtuoso/src/main/java/zone/cogni/semanticz/connectors/virtuoso/VirtuosoApacheHttpClientRdfStoreService.java
@@ -56,6 +56,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+import static zone.cogni.semanticz.connectors.utils.Constants.TEXT_TURTLE;
+
 /**
  * Implementation of VirtuosoRdfStoreService backed directly by Apache HttpClient.
  */
@@ -120,7 +123,7 @@ public class VirtuosoApacheHttpClientRdfStoreService implements RdfStoreService 
     log.info("Calling {} with basic auth: {}", url, graphCrudUseBasicAuth);
     HttpEntityEnclosingRequestBase request = replace ? new HttpPut(url) : new HttpPost(url);
     request.setEntity(new ByteArrayEntity(data));
-    request.setHeader("Content-Type", "text/turtle;charset=utf-8");
+    request.setHeader(CONTENT_TYPE, TEXT_TURTLE + ";charset=utf-8");
     if (graphCrudUseBasicAuth) {
       request.setHeader("Authorization", "Basic " + Base64.encodeBase64String(
           (rdfStoreUser + ":" + rdfStorePassword).getBytes(StandardCharsets.UTF_8)));

--- a/semanticz-connector-virtuoso/src/test/java/zone/cogni/semanticz/connectors/virtuoso/VirtuosoSparqlServiceTest.java
+++ b/semanticz-connector-virtuoso/src/test/java/zone/cogni/semanticz/connectors/virtuoso/VirtuosoSparqlServiceTest.java
@@ -33,6 +33,8 @@ import zone.cogni.semanticz.connectors.utils.ApacheHttpClientUtils;
 import zone.cogni.semanticz.connectors.utils.AbstractSparqlServiceTest;
 import zone.cogni.semanticz.connectors.general.Config;
 
+import static zone.cogni.semanticz.connectors.utils.Constants.TEXT_TURTLE;
+
 @Disabled("An integration test dependent on a running Virtuoso instance. To run it manually, set the Config below properly and run the tests.")
 public class VirtuosoSparqlServiceTest extends AbstractSparqlServiceTest<VirtuosoSparqlService> {
 
@@ -61,7 +63,7 @@ public class VirtuosoSparqlServiceTest extends AbstractSparqlServiceTest<Virtuos
       final String url = VirtuosoHelper.getVirtuosoUpdateUrl(config.getUrl(), name);
       ApacheHttpClientUtils.executeAuthenticatedPostOrPut(url, config.getUser(), config.getPassword(),
               config.isGraphCrudUseBasicAuth(), new ByteArrayEntity(w.toString().getBytes()), true,
-              "text/turtle;charset=utf-8");
+              TEXT_TURTLE + ";charset=utf-8");
     }
 
     return new VirtuosoSparqlService(config);

--- a/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/general/SparqlService.java
+++ b/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/general/SparqlService.java
@@ -98,6 +98,10 @@ public interface SparqlService {
    * @return true if the graph does not contain any triple. Note that this methods might return false also in case the graph even does not exist.
    */
   default boolean isEmptyGraph(String graphIri) {
-    return !executeAskQuery(String.format("ASK { GRAPH <%s> {?s ?p ?o}}", graphIri));
+    if (graphIri == null) {
+      return !executeAskQuery("ASK WHERE { ?s ?p ?o FILTER NOT EXISTS { GRAPH ?g { ?s ?p ?o } } }");
+    } else {
+      return !executeAskQuery(String.format("ASK { GRAPH <%s> {?s ?p ?o}}", graphIri));
+    }
   }
 }

--- a/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/AbstractSparqlServiceTest.java
+++ b/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/AbstractSparqlServiceTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractSparqlServiceTest<T extends SparqlService> {
             getClass().getResource("/dataset.trig")).toURI().toURL().openStream()).lang(Lang.TRIG).parse(dataset);
 
     String data = RDFWriter.source(dataset.getDefaultModel()).format(RDFFormat.NTRIPLES).asString();
-    sut.executeUpdateQuery("DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }");
+    sut.executeUpdateQuery("DELETE { GRAPH ?g { ?s ?p ?o } } WHERE { GRAPH ?g { ?s ?p ?o } }");
     sut.executeUpdateQuery("INSERT DATA { " + data + " }");
     final Iterator<String> graphs = dataset.listNames();
     while (graphs.hasNext()) {
@@ -118,7 +118,7 @@ public abstract class AbstractSparqlServiceTest<T extends SparqlService> {
   public void testUploadTtlFileWorksCorrectly() throws IOException {
     final Path dir = Files.createTempDirectory("testUploadTtlFileWorksCorrectly-");
     final String fileName = "testUploadTtlFileWorksCorrectly.ttl";
-    final File file = Files.createTempFile(dir, fileName, "").toFile();
+    final File file = Files.createTempFile(dir, fileName, ".ttl").toFile();
     try {
       final Model model = ModelFactory.createDefaultModel();
       model.add(createResource(r("c1")), RDFS.comment, "comment");
@@ -130,7 +130,6 @@ public abstract class AbstractSparqlServiceTest<T extends SparqlService> {
       sut.uploadTtlFile(file);
       Assertions.assertTrue(sut.executeAskQuery(checkTripleExists));
     } finally {
-      sut.dropGraph(file.toURI().toString());
       file.delete();
     }
   }

--- a/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/Constants.java
+++ b/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/Constants.java
@@ -23,8 +23,8 @@ public final class Constants {
   public static final String APPLICATION_FORM_URLENCODED_VALUE = "application/x-www-form-urlencoded";
   public static final String APPLICATION_SPARQL_RESULTS_XML = "application/sparql-results+xml";
   public static final String APPLICATION_SPARQL_QUERY = "application/sparql-query";
-  public static final String CONTENT_TYPE = "Content-Type";
   public static final String TEXT_TURTLE = "text/turtle";
+  public static final String CONTENT_TYPE = "Content-Type";
 
   private Constants() {
     throw new UnsupportedOperationException();

--- a/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/Constants.java
+++ b/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/Constants.java
@@ -22,6 +22,7 @@ package zone.cogni.semanticz.connectors.utils;
 public final class Constants {
   public static final String APPLICATION_FORM_URLENCODED_VALUE = "application/x-www-form-urlencoded";
   public static final String APPLICATION_SPARQL_RESULTS_XML = "application/sparql-results+xml";
+  public static final String APPLICATION_SPARQL_QUERY = "application/sparql-query";
   public static final String TEXT_TURTLE = "text/turtle";
 
   private Constants() {

--- a/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/Constants.java
+++ b/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/Constants.java
@@ -23,6 +23,7 @@ public final class Constants {
   public static final String APPLICATION_FORM_URLENCODED_VALUE = "application/x-www-form-urlencoded";
   public static final String APPLICATION_SPARQL_RESULTS_XML = "application/sparql-results+xml";
   public static final String APPLICATION_SPARQL_QUERY = "application/sparql-query";
+  public static final String CONTENT_TYPE = "Content-Type";
   public static final String TEXT_TURTLE = "text/turtle";
 
   private Constants() {


### PR DESCRIPTION
Changes before splitting the codebase for Java 11/Java 17:
- fix tests for Virtuoso
- fix handling isEmptyGraph for a default graph
- minor code cleanup