### PR TITLE
Refactor GraphDBSparqlService updateGraph and add RdfSparqlService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 build
 .gradle
+/CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+next release
+- added GraphDB RdfStoreService implementation
+
 2.0.0
 - migration to Java 17 and Jena 5
 - added license headers

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBConfig.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBConfig.java
@@ -30,6 +30,7 @@ import zone.cogni.semanticz.connectors.general.Config;
 public class GraphDBConfig extends Config {
 
   private String repository;
+  private Integer connectTimeoutSeconds = 5; // Default to 5 seconds
 
   public GraphDBConfig() {
   }

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
@@ -209,7 +209,7 @@ public class GraphDBRdfStoreService implements RdfStoreService {
 
     @Override
     public void close() {
-        super.close();
+        RdfStoreService.super.close();
     }
 
     private void executeHttpRequest(HttpRequest request, int... expectedCodes) {

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package zone.cogni.semanticz.connectors.graphdb;
 
 import org.apache.commons.lang3.StringUtils;
@@ -190,7 +209,7 @@ public class GraphDBRdfStoreService implements RdfStoreService {
 
     @Override
     public void close() {
-        RdfStoreService.super.close();
+        super.close();
     }
 
     private void executeHttpRequest(HttpRequest request, int... expectedCodes) {

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
@@ -45,6 +45,8 @@ import java.util.Objects;
 public class GraphDBRdfStoreService implements RdfStoreService {
 
     private static final Logger log = LoggerFactory.getLogger(GraphDBRdfStoreService.class);
+    private static final String HTTP_METHOD_PUT = "PUT";
+    private static final String HTTP_METHOD_POST = "POST";
 
     private final GraphDBConfig config;
     private volatile HttpClient httpClient;
@@ -87,50 +89,57 @@ public class GraphDBRdfStoreService implements RdfStoreService {
         addData(model, null);   // default graph
     }
 
-    @Override
-    public void addData(Model model, String graphUri) {
-        Objects.requireNonNull(model, "model must not be null");
-
+    private String modelToTurtle(Model model) {
         StringWriter writer = new StringWriter();
         model.write(writer, "ttl");
-        String turtle = writer.toString();
+        return writer.toString();
+    }
 
+    private URI buildEndpoint(String graphUri) {
         String endpoint = config.getSparqlUpdateEndpoint();
         if (StringUtils.isNotBlank(graphUri)) {
             String encCtx = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
             endpoint = endpoint + "?context=" + encCtx;
         }
+        return URI.create(endpoint);
+    }
 
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(endpoint))
-                .header("Content-Type", Lang.TURTLE.getHeaderString()) // text/turtle
-                .POST(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8))
-                .build();
+    private void sendData(Model model, String graphUri, String httpMethod) {
+        String turtle = modelToTurtle(model);
+        URI endpoint = buildEndpoint(graphUri);
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(endpoint)
+                .header("Content-Type", Lang.TURTLE.getHeaderString()); // text/turtle
+
+        HttpRequest request;
+        if (HTTP_METHOD_PUT.equals(httpMethod)) {
+            request = requestBuilder.PUT(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8)).build();
+        } else {
+            request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8)).build();
+        }
 
         executeHttpRequest(request, 200, 202, 204);
-        log.debug("Uploaded {} triples to {}", model.size(), graphUri == null ? "default graph" : graphUri);
+        
+        String graphName = graphUri == null ? "default graph" : graphUri;
+        if (HTTP_METHOD_PUT.equals(httpMethod)) {
+            log.debug("Graph {} successfully replaced with {} triples.", graphName, model.size());
+        } else {
+            log.debug("Uploaded {} triples to {}", model.size(), graphName);
+        }
+    }
+
+    @Override
+    public void addData(Model model, String graphUri) {
+        Objects.requireNonNull(model, "model must not be null");
+        sendData(model, graphUri, HTTP_METHOD_POST);
     }
 
     @Override
     public void replaceGraph(String graphUri, Model model) {
         Objects.requireNonNull(graphUri, "graphUri must not be null");
         Objects.requireNonNull(model, "model must not be null");
-
-        StringWriter writer = new StringWriter();
-        model.write(writer, "ttl");
-        String turtle = writer.toString();
-
-        String encodedCtx = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
-        URI endpoint = URI.create(config.getSparqlUpdateEndpoint() + "?context=" + encodedCtx);
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(endpoint)
-                .header("Content-Type", Lang.TURTLE.getHeaderString())    // text/turtle
-                .PUT(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8))
-                .build();
-
-        executeHttpRequest(request, 200, 202, 204);
-        log.debug("Graph {} successfully replaced with {} triples.", graphUri, model.size());
+        sendData(model, graphUri, HTTP_METHOD_PUT);
     }
 
     @Override

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBRdfStoreService.java
@@ -1,0 +1,215 @@
+package zone.cogni.semanticz.connectors.graphdb;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import zone.cogni.sem.jena.template.JenaResultSetHandler;
+import zone.cogni.semanticz.connectors.general.RdfStoreService;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.*;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
+
+@Deprecated
+public class GraphDBRdfStoreService implements RdfStoreService {
+
+    private static final Logger log = LoggerFactory.getLogger(GraphDBRdfStoreService.class);
+
+    private final GraphDBConfig config;
+    private volatile HttpClient httpClient;
+
+    public GraphDBRdfStoreService(GraphDBConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    private static boolean hasBindings(QuerySolution qs) {
+        return qs != null && qs.varNames().hasNext();
+    }
+
+    private synchronized HttpClient getHttpClient() {
+        if (httpClient != null) return httpClient;
+
+        HttpClient.Builder builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(Redirect.NORMAL)
+                .proxy(ProxySelector.getDefault());
+
+        if (StringUtils.isNoneBlank(config.getUser(), config.getPassword())) {
+            builder.authenticator(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(
+                            config.getUser(), config.getPassword().toCharArray());
+                }
+            });
+        } else if (!StringUtils.isAllBlank(config.getUser(), config.getPassword())) {
+            log.error("GraphDB credentials are incomplete: user='{}', pwd='{}'",
+                    config.getUser(), config.getPassword());
+        }
+
+        httpClient = builder.build();
+        return httpClient;
+    }
+
+    @Override
+    public void addData(Model model) {
+        addData(model, null);   // default graph
+    }
+
+    @Override
+    public void addData(Model model, String graphUri) {
+        Objects.requireNonNull(model, "model must not be null");
+
+        StringWriter writer = new StringWriter();
+        model.write(writer, "ttl");
+        String turtle = writer.toString();
+
+        String endpoint = config.getSparqlUpdateEndpoint();
+        if (StringUtils.isNotBlank(graphUri)) {
+            String encCtx = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
+            endpoint = endpoint + "?context=" + encCtx;
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(endpoint))
+                .header("Content-Type", Lang.TURTLE.getHeaderString()) // text/turtle
+                .POST(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8))
+                .build();
+
+        executeHttpRequest(request, 200, 202, 204);
+        log.debug("Uploaded {} triples to {}", model.size(), graphUri == null ? "default graph" : graphUri);
+    }
+
+    @Override
+    public void replaceGraph(String graphUri, Model model) {
+        Objects.requireNonNull(graphUri, "graphUri must not be null");
+        Objects.requireNonNull(model, "model must not be null");
+
+        StringWriter writer = new StringWriter();
+        model.write(writer, "ttl");
+        String turtle = writer.toString();
+
+        String encodedCtx = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
+        URI endpoint = URI.create(config.getSparqlUpdateEndpoint() + "?context=" + encodedCtx);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(endpoint)
+                .header("Content-Type", Lang.TURTLE.getHeaderString())    // text/turtle
+                .PUT(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8))
+                .build();
+
+        executeHttpRequest(request, 200, 202, 204);
+        log.debug("Graph {} successfully replaced with {} triples.", graphUri, model.size());
+    }
+
+    @Override
+    public <R> R executeSelectQuery(Query query,
+                                    QuerySolutionMap bindings,
+                                    JenaResultSetHandler<R> resultHandler,
+                                    String context) {
+
+        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.service(config.getSparqlEndpoint())
+                .query(query)
+                .httpClient(getHttpClient());
+
+        if (hasBindings(bindings)) {
+            builder.substitution(bindings);
+        }
+
+        if (StringUtils.isNotBlank(context)) {
+            builder.param("context-uri", context);
+        }
+
+        try (QueryExecution qexec = builder.build()) {
+            ResultSet rs = qexec.execSelect();
+            return resultHandler.handle(rs);
+        }
+    }
+
+    @Override
+    public boolean executeAskQuery(Query query, QuerySolutionMap bindings) {
+        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.service(config.getSparqlEndpoint())
+                .query(query)
+                .httpClient(getHttpClient());
+
+        if (hasBindings(bindings)) {
+            builder.substitution(bindings);
+        }
+
+        try (QueryExecution qexec = builder.build()) {
+            return qexec.execAsk();
+        }
+    }
+
+    @Override
+    public Model executeConstructQuery(Query query, QuerySolutionMap bindings) {
+        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP.service(config.getSparqlEndpoint())
+                .query(query)
+                .httpClient(getHttpClient());
+
+        if (hasBindings(bindings)) {
+            builder.substitution(bindings);
+        }
+
+        try (QueryExecution qexec = builder.build()) {
+            return qexec.execConstruct();
+        }
+    }
+
+    @Override
+    public void executeUpdateQuery(String updateQuery) {
+        String formBody = "update=" + URLEncoder.encode(updateQuery, StandardCharsets.UTF_8);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.getSparqlUpdateEndpoint()))
+                .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+                .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                .build();
+
+        executeHttpRequest(request, 204);
+        log.debug("SPARQL‑UPDATE executed successfully (204 NO CONTENT)");
+    }
+
+    @Override
+    public void delete() {
+        executeUpdateQuery("CLEAR ALL");
+        log.info("Repository {} cleared with 'CLEAR ALL'.", config.getRepository());
+    }
+
+    @Override
+    public void close() {
+        RdfStoreService.super.close();
+    }
+
+    private void executeHttpRequest(HttpRequest request, int... expectedCodes) {
+        try {
+            HttpResponse<String> resp = getHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.ofString());
+
+            int actual = resp.statusCode();
+            for (int expected : expectedCodes) {
+                if (actual == expected) return;
+            }
+
+            String body = StringUtils.defaultIfBlank(resp.body(), "<no body>");
+            throw new RuntimeException(
+                    "GraphDB request to " + request.uri() + " failed. HTTP " + actual + ". " + body);
+
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("I/O error talking to GraphDB", e);
+        }
+    }
+}

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
@@ -1,6 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package zone.cogni.semanticz.connectors.graphdb;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
@@ -11,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zone.cogni.semanticz.connectors.general.SparqlService;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.*;
@@ -23,12 +40,15 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.function.Function;
 
-
 public class GraphDBSparqlService implements SparqlService {
 
     private static final Logger log = LoggerFactory.getLogger(GraphDBSparqlService.class);
     private final GraphDBConfig config;
     private HttpClient httpClient;
+
+    public GraphDBSparqlService(GraphDBConfig config) {
+        this.config = config;
+    }
 
     private synchronized HttpClient getHttpClient() {
         if (httpClient != null) return httpClient;
@@ -53,10 +73,6 @@ public class GraphDBSparqlService implements SparqlService {
 
         httpClient = builder.build();
         return httpClient;
-    }
-
-    public GraphDBSparqlService(GraphDBConfig config) {
-        this.config = config;
     }
 
     @Override
@@ -117,7 +133,7 @@ public class GraphDBSparqlService implements SparqlService {
     @Override
     public void updateGraph(String graphUri, Model model) {
         Objects.requireNonNull(graphUri, "graphUri must not be null");
-        Objects.requireNonNull(model,    "model must not be null");
+        Objects.requireNonNull(model, "model must not be null");
 
         if (model.isEmpty()) {
             log.debug("addData called with an empty model – nothing to do.");

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
@@ -28,6 +28,7 @@ import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import zone.cogni.semanticz.connectors.general.SparqlService;
+import zone.cogni.semanticz.connectors.utils.HttpClientUtils;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -43,6 +44,9 @@ import java.util.function.Function;
 public class GraphDBSparqlService implements SparqlService {
 
     private static final Logger log = LoggerFactory.getLogger(GraphDBSparqlService.class);
+    private static final String HTTP_METHOD_PUT = "PUT";
+    private static final String HTTP_METHOD_POST = "POST";
+    
     private final GraphDBConfig config;
     private HttpClient httpClient;
 
@@ -53,25 +57,14 @@ public class GraphDBSparqlService implements SparqlService {
     private synchronized HttpClient getHttpClient() {
         if (httpClient != null) return httpClient;
 
-        HttpClient.Builder builder = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(5))
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .proxy(ProxySelector.getDefault());
-
-        if (StringUtils.isNoneBlank(config.getUser(), config.getPassword())) {
-            builder.authenticator(new Authenticator() {
-                @Override
-                protected PasswordAuthentication getPasswordAuthentication() {
-                    return new PasswordAuthentication(
-                            config.getUser(),
-                            config.getPassword().toCharArray());
-                }
-            });
-        } else if (!StringUtils.isAllBlank(config.getUser(), config.getPassword())) {
-            log.error("Endpoint credentials not properly configured");
-        }
-
-        httpClient = builder.build();
+        httpClient = HttpClientUtils.createHttpClientBuilder(
+                config.getUser(),
+                config.getPassword(),
+                Duration.ofSeconds(config.getConnectTimeoutSeconds()),
+                true,  // followRedirects
+                true   // useSystemProxy
+        ).build();
+        
         return httpClient;
     }
 
@@ -104,22 +97,23 @@ public class GraphDBSparqlService implements SparqlService {
         executeHttpRequest(request, 204);
     }
 
-    @Override
-    public <R> R executeSelectQuery(String query, Function<ResultSet, R> resultHandler) {
-        try (QueryExecution queryExecution = QueryExecutionHTTP.service(config.getSparqlEndpoint())
+    private QueryExecution createQueryExecution(String query) {
+        return QueryExecutionHTTP.service(config.getSparqlEndpoint())
                 .queryString(query)
                 .httpClient(getHttpClient())
-                .build()) {
+                .build();
+    }
+
+    @Override
+    public <R> R executeSelectQuery(String query, Function<ResultSet, R> resultHandler) {
+        try (QueryExecution queryExecution = createQueryExecution(query)) {
             return resultHandler.apply(queryExecution.execSelect());
         }
     }
 
     @Override
     public boolean executeAskQuery(String askQuery) {
-        try (QueryExecution queryExecution = QueryExecutionHTTP.service(config.getSparqlEndpoint())
-                .queryString(askQuery)
-                .httpClient(getHttpClient())
-                .build()) {
+        try (QueryExecution queryExecution = createQueryExecution(askQuery)) {
             return queryExecution.execAsk();
         }
     }
@@ -130,34 +124,33 @@ public class GraphDBSparqlService implements SparqlService {
         executeUpdateQuery("clear graph <" + graphUri + ">");
     }
 
-    @Override
-    public void updateGraph(String graphUri, Model model) {
-        Objects.requireNonNull(graphUri, "graphUri must not be null");
-        Objects.requireNonNull(model, "model must not be null");
-
-        if (model.isEmpty()) {
-            log.debug("addData called with an empty model – nothing to do.");
-            return;
-        }
-
+    private String modelToTurtle(Model model) {
         StringWriter writer = new StringWriter();
         model.write(writer, "ttl");
-        String turtle = writer.toString();
+        return writer.toString();
+    }
 
-        String base = config.getSparqlUpdateEndpoint();      // …/statements
-        URI endpoint;
+    private URI buildGraphEndpoint(String graphUri, boolean isReplace) {
+        String base = config.getSparqlUpdateEndpoint();
         if (StringUtils.isBlank(graphUri)) {
-            endpoint = URI.create(base);                       // default graph
+            return URI.create(base);  // default graph
         } else {
             String encCtx = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
-            endpoint = URI.create(base + "?context=" + encCtx); // named graph
+            return URI.create(base + "?context=" + encCtx);
         }
+    }
 
-        HttpRequest request = HttpRequest.newBuilder()
+    private void sendGraphData(URI endpoint, String turtleContent, String httpMethod, String graphUri, long modelSize) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(endpoint)
-                .header("Content-Type", Lang.TURTLE.getHeaderString()) // text/turtle
-                .POST(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8))
-                .build();
+                .header("Content-Type", Lang.TURTLE.getHeaderString()); // text/turtle
+
+        HttpRequest request;
+        if (HTTP_METHOD_PUT.equals(httpMethod)) {
+            request = requestBuilder.PUT(HttpRequest.BodyPublishers.ofString(turtleContent, StandardCharsets.UTF_8)).build();
+        } else {
+            request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(turtleContent, StandardCharsets.UTF_8)).build();
+        }
 
         try {
             HttpResponse<Void> resp = getHttpClient()
@@ -165,16 +158,39 @@ public class GraphDBSparqlService implements SparqlService {
 
             int code = resp.statusCode();
             if (code != 200 && code != 202 && code != 204) {
-                throw new RuntimeException("Failed to add data. HTTP " + code);
+                String action = HTTP_METHOD_PUT.equals(httpMethod) ? "replace" : "update";
+                log.error("Failed to {} graph. HTTP {} {}", action, code, resp);
+                throw new RuntimeException("Failed to " + action + " graph. HTTP " + code);
             }
-            log.debug("Uploaded {} triples to {}", model.size(),
-                    StringUtils.defaultIfBlank(graphUri, "default graph"));
+            
+            String graphName = StringUtils.defaultIfBlank(graphUri, "default graph");
+            if (HTTP_METHOD_PUT.equals(httpMethod)) {
+                log.debug("Graph {} successfully replaced with {} triples (HTTP {})", graphName, modelSize, code);
+            } else {
+                log.debug("Uploaded {} triples to {}", modelSize, graphName);
+            }
 
         } catch (IOException | InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException("I/O error while uploading triples", e);
+            String action = HTTP_METHOD_PUT.equals(httpMethod) ? "replacing" : "uploading to";
+            log.error("I/O error while {} graph", action, e);
+            throw new RuntimeException("I/O error while " + action + " graph", e);
         }
-        log.debug("Added {} triples to existing graph {}", model.size(), graphUri);
+    }
+
+    @Override
+    public void updateGraph(String graphUri, Model model) {
+        Objects.requireNonNull(graphUri, "graphUri must not be null");
+        Objects.requireNonNull(model, "model must not be null");
+
+        if (model.isEmpty()) {
+            log.debug("updateGraph called with an empty model – nothing to do.");
+            return;
+        }
+
+        String turtle = modelToTurtle(model);
+        URI endpoint = buildGraphEndpoint(graphUri, false);
+        sendGraphData(endpoint, turtle, HTTP_METHOD_POST, graphUri, model.size());
     }
 
     private void executeHttpRequest(HttpRequest request, int expectedCode) {
@@ -207,37 +223,14 @@ public class GraphDBSparqlService implements SparqlService {
 
     @Override
     public void replaceGraph(String graphUri, Model model) {
-        StringWriter writer = new StringWriter();
-        model.write(writer, "ttl");
-        String turtleContent = writer.toString();
+        Objects.requireNonNull(graphUri, "graphUri must not be null");
+        Objects.requireNonNull(model, "model must not be null");
 
         log.info("Replacing graph {} with single PUT request", graphUri);
 
-        String encoded = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
-        URI endpoint = URI.create(config.getSparqlUpdateEndpoint() + "?context=" + encoded);
-
-        HttpRequest request = HttpRequest.newBuilder()
-                .uri(endpoint)
-                .header("Content-Type", Lang.TURTLE.getHeaderString())   // "text/turtle"
-                .PUT(HttpRequest.BodyPublishers.ofString(turtleContent, StandardCharsets.UTF_8))
-                .build();
-
-        try {
-            HttpResponse<Void> resp = getHttpClient()
-                    .send(request, HttpResponse.BodyHandlers.discarding());
-
-            int code = resp.statusCode();
-            if (code != 200 && code != 204 && code != 202) {
-                log.error("Failed to upload Turtle data. HTTP {} {}", code, resp);
-                throw new RuntimeException("Failed to upload TTL data. HTTP " + code);
-            }
-            log.debug("Graph {} successfully replaced (HTTP {})", graphUri, code);
-
-        } catch (IOException | InterruptedException e) {
-            Thread.currentThread().interrupt();               // preserve interrupt flag
-            log.error("Error replacing Turtle data to GraphDB", e);
-            throw new RuntimeException("I/O error during graph replacement", e);
-        }
+        String turtleContent = modelToTurtle(model);
+        URI endpoint = buildGraphEndpoint(graphUri, true);
+        sendGraphData(endpoint, turtleContent, HTTP_METHOD_PUT, graphUri, model.size());
     }
 
 }

--- a/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
+++ b/semanticz-connector-graphdb/src/main/java/zone/cogni/semanticz/connectors/graphdb/GraphDBSparqlService.java
@@ -1,125 +1,227 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 package zone.cogni.semanticz.connectors.graphdb;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionBuilder;
-import org.apache.jena.query.ResultSet;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.riot.Lang;
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
-import zone.cogni.semanticz.connectors.utils.Constants;
-import zone.cogni.semanticz.connectors.utils.HttpClientUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import zone.cogni.semanticz.connectors.general.SparqlService;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.net.URI;
-import java.net.URLEncoder;
+import java.net.*;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Objects;
 import java.util.function.Function;
 
-import static zone.cogni.semanticz.connectors.utils.Constants.CONTENT_TYPE;
-import static zone.cogni.semanticz.connectors.utils.HttpClientUtils.execute;
 
 public class GraphDBSparqlService implements SparqlService {
 
-  private final GraphDBConfig config;
-  private final HttpClient httpClient;
+    private static final Logger log = LoggerFactory.getLogger(GraphDBSparqlService.class);
+    private final GraphDBConfig config;
+    private HttpClient httpClient;
 
-  public GraphDBSparqlService(GraphDBConfig config) {
-    this.config = config;
-    //  TODO check loading from systemproperties - e.g. proxy settings?
-    //  HttpClientBuilder httpClientBuilder = HttpClients.custom().useSystemProperties();
-    httpClient = HttpClientUtils.createHttpClientBuilder(config.getUser(), config.getPassword()).build();
-  }
+    private synchronized HttpClient getHttpClient() {
+        if (httpClient != null) return httpClient;
 
-  private QueryExecutionBuilder getQueryExecutionBuilder() {
-    return QueryExecutionHTTPBuilder.service(config.getSparqlEndpoint()).httpClient(httpClient);
-  }
+        HttpClient.Builder builder = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .proxy(ProxySelector.getDefault());
 
-  @Override
-  public void uploadTtlFile(File file) {
-    try {
-      uploadTtl(file.toURI().toString(), FileUtils.readFileToString(file, "UTF-8"));
+        if (StringUtils.isNoneBlank(config.getUser(), config.getPassword())) {
+            builder.authenticator(new Authenticator() {
+                @Override
+                protected PasswordAuthentication getPasswordAuthentication() {
+                    return new PasswordAuthentication(
+                            config.getUser(),
+                            config.getPassword().toCharArray());
+                }
+            });
+        } else if (!StringUtils.isAllBlank(config.getUser(), config.getPassword())) {
+            log.error("Endpoint credentials not properly configured");
+        }
+
+        httpClient = builder.build();
+        return httpClient;
     }
-    catch (IOException e) {
-      throw new RuntimeException("Couldn't read file " + file.getName(), e);
+
+    public GraphDBSparqlService(GraphDBConfig config) {
+        this.config = config;
     }
-  }
 
-  @Override
-  public void updateGraph(String graphUri, Model model) {
-    StringWriter writer = new StringWriter();
-    model.write(writer, "ttl");
-    uploadTtl(graphUri, writer.toString());
-  }
+    @Override
+    public Model executeConstructQuery(String constructQuery) {
+        Objects.requireNonNull(constructQuery, "constructQuery must not be null");
 
-  private void uploadTtl(String graphUri, String ttl) {
-    final HttpRequest request = HttpRequest
-        .newBuilder()
-        .POST(BodyPublishers.ofString(ttl, StandardCharsets.UTF_8))
-        .header(CONTENT_TYPE, Lang.TURTLE.getHeaderString())
-        .uri(URI.create(config.getSparqlUpdateEndpoint()+"?context=" + URLEncoder.encode("<"+graphUri+">", StandardCharsets.UTF_8)))
-        .build();
-    execute(request, httpClient);
-  }
+        Query query = QueryFactory.create(constructQuery, Syntax.syntaxARQ);
 
-  @Override
-  public Model executeConstructQuery(String query) {
-    try (QueryExecution queryExecution = getQueryExecutionBuilder().query(query).build()) {
-      return queryExecution.execConstruct();
+        QueryExecutionHTTPBuilder builder = QueryExecutionHTTP
+                .service(config.getSparqlEndpoint())
+                .query(query)
+                .httpClient(getHttpClient());
+
+        try (QueryExecution qExec = builder.build()) {
+            return qExec.execConstruct();
+        }
     }
-  }
 
-  @Override
-  public void executeUpdateQuery(String updateQuery) {
-    final HttpRequest request = HttpRequest
-        .newBuilder(URI.create(config.getSparqlUpdateEndpoint()))
-        .POST(BodyPublishers.ofString("update=" + URLEncoder.encode(updateQuery, StandardCharsets.UTF_8), StandardCharsets.UTF_8))
-        .header(CONTENT_TYPE, Constants.APPLICATION_FORM_URLENCODED_VALUE)
-        .build();
-    execute(request, httpClient);
-  }
+    @Override
+    public void executeUpdateQuery(String updateQuery) {
+        String formBody = "update=" + URLEncoder.encode(updateQuery, StandardCharsets.UTF_8);
 
-  @Override
-  public <R> R executeSelectQuery(String query, Function<ResultSet, R> resultHandler) {
-    try (QueryExecution queryExecution = getQueryExecutionBuilder().query(query).build()) {
-      return resultHandler.apply(queryExecution.execSelect());
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(config.getSparqlUpdateEndpoint()))
+                .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+                .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                .build();
+
+        executeHttpRequest(request, 204);
     }
-  }
 
-  @Override
-  public boolean executeAskQuery(String askQuery) {
-    try (QueryExecution queryExecution = getQueryExecutionBuilder().query(askQuery).build()) {
-      return queryExecution.execAsk();
+    @Override
+    public <R> R executeSelectQuery(String query, Function<ResultSet, R> resultHandler) {
+        try (QueryExecution queryExecution = QueryExecutionHTTP.service(config.getSparqlEndpoint())
+                .queryString(query)
+                .httpClient(getHttpClient())
+                .build()) {
+            return resultHandler.apply(queryExecution.execSelect());
+        }
     }
-  }
 
-  @Override
-  public void dropGraph(String graphUri) {
-    executeUpdateQuery("CLEAR SILENT GRAPH <" + graphUri + ">");
-  }
+    @Override
+    public boolean executeAskQuery(String askQuery) {
+        try (QueryExecution queryExecution = QueryExecutionHTTP.service(config.getSparqlEndpoint())
+                .queryString(askQuery)
+                .httpClient(getHttpClient())
+                .build()) {
+            return queryExecution.execAsk();
+        }
+    }
+
+
+    @Override
+    public void dropGraph(String graphUri) {
+        executeUpdateQuery("clear graph <" + graphUri + ">");
+    }
+
+    @Override
+    public void updateGraph(String graphUri, Model model) {
+        Objects.requireNonNull(graphUri, "graphUri must not be null");
+        Objects.requireNonNull(model,    "model must not be null");
+
+        if (model.isEmpty()) {
+            log.debug("addData called with an empty model – nothing to do.");
+            return;
+        }
+
+        StringWriter writer = new StringWriter();
+        model.write(writer, "ttl");
+        String turtle = writer.toString();
+
+        String base = config.getSparqlUpdateEndpoint();      // …/statements
+        URI endpoint;
+        if (StringUtils.isBlank(graphUri)) {
+            endpoint = URI.create(base);                       // default graph
+        } else {
+            String encCtx = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
+            endpoint = URI.create(base + "?context=" + encCtx); // named graph
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(endpoint)
+                .header("Content-Type", Lang.TURTLE.getHeaderString()) // text/turtle
+                .POST(HttpRequest.BodyPublishers.ofString(turtle, StandardCharsets.UTF_8))
+                .build();
+
+        try {
+            HttpResponse<Void> resp = getHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.discarding());
+
+            int code = resp.statusCode();
+            if (code != 200 && code != 202 && code != 204) {
+                throw new RuntimeException("Failed to add data. HTTP " + code);
+            }
+            log.debug("Uploaded {} triples to {}", model.size(),
+                    StringUtils.defaultIfBlank(graphUri, "default graph"));
+
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("I/O error while uploading triples", e);
+        }
+        log.debug("Added {} triples to existing graph {}", model.size(), graphUri);
+    }
+
+    private void executeHttpRequest(HttpRequest request, int expectedCode) {
+        try {
+            HttpResponse<String> response =
+                    getHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+            checkResponse(response, expectedCode);
+
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void checkResponse(HttpResponse<String> response, int expectedCode) {
+        int actual = response.statusCode();
+        if (actual == expectedCode) return;
+
+        String body = response.body();
+        if (body == null || body.isBlank()) {
+            body = "No response body from server.";
+        }
+
+        String msg = "Update didn't answer " + expectedCode +
+                " code: HTTP " + actual + ". " + body;
+
+        throw new RuntimeException(msg);
+    }
+
+    @Override
+    public void replaceGraph(String graphUri, Model model) {
+        StringWriter writer = new StringWriter();
+        model.write(writer, "ttl");
+        String turtleContent = writer.toString();
+
+        log.info("Replacing graph {} with single PUT request", graphUri);
+
+        String encoded = URLEncoder.encode("<" + graphUri + ">", StandardCharsets.UTF_8);
+        URI endpoint = URI.create(config.getSparqlUpdateEndpoint() + "?context=" + encoded);
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(endpoint)
+                .header("Content-Type", Lang.TURTLE.getHeaderString())   // "text/turtle"
+                .PUT(HttpRequest.BodyPublishers.ofString(turtleContent, StandardCharsets.UTF_8))
+                .build();
+
+        try {
+            HttpResponse<Void> resp = getHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.discarding());
+
+            int code = resp.statusCode();
+            if (code != 200 && code != 204 && code != 202) {
+                log.error("Failed to upload Turtle data. HTTP {} {}", code, resp);
+                throw new RuntimeException("Failed to upload TTL data. HTTP " + code);
+            }
+            log.debug("Graph {} successfully replaced (HTTP {})", graphUri, code);
+
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();               // preserve interrupt flag
+            log.error("Error replacing Turtle data to GraphDB", e);
+            throw new RuntimeException("I/O error during graph replacement", e);
+        }
+    }
+
 }

--- a/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/HttpClientUtils.java
+++ b/semanticz-connectors-common/src/main/java/zone/cogni/semanticz/connectors/utils/HttpClientUtils.java
@@ -25,10 +25,12 @@ import org.slf4j.LoggerFactory;
 
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
+import java.net.ProxySelector;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.text.MessageFormat;
+import java.time.Duration;
 
 /**
  * Utility methods for JDK11 HttpClient.
@@ -59,6 +61,45 @@ public class HttpClientUtils {
       log.error("Endpoint credentials not properly configured");
     }
     return httpClientBuilder;
+  }
+
+  /**
+   * Creates a new HttpClientBuilder with additional configuration options.
+   * If both username and password are supplied, basic authentication is configured.
+   *
+   * @param username username (optional)
+   * @param password password (optional)
+   * @param connectTimeout connection timeout (optional, defaults to 5 seconds if null)
+   * @param followRedirects whether to follow redirects
+   * @param useSystemProxy whether to use system proxy settings
+   * @return HttpClient.Builder
+   */
+  public static HttpClient.Builder createHttpClientBuilder(final String username,
+      final String password,
+      final Duration connectTimeout,
+      final boolean followRedirects,
+      final boolean useSystemProxy) {
+    final HttpClient.Builder builder = HttpClient.newBuilder()
+        .connectTimeout(connectTimeout != null ? connectTimeout : Duration.ofSeconds(5))
+        .followRedirects(followRedirects ? HttpClient.Redirect.NORMAL : HttpClient.Redirect.NEVER);
+
+    if (useSystemProxy) {
+      builder.proxy(ProxySelector.getDefault());
+    }
+
+    if (StringUtils.isNoneBlank(username, password)) {
+      builder.authenticator(new Authenticator() {
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+          return new PasswordAuthentication(username, password.toCharArray());
+        }
+      });
+    } else if (!StringUtils.isAllBlank(username, password)) {
+      log.error("Endpoint credentials are incomplete: user='{}', password provided='{}'",
+          username, StringUtils.isNotBlank(password));
+    }
+
+    return builder;
   }
 
   /**


### PR DESCRIPTION
Refactor GraphDBSparqlService updateGraph and add RdfSparqlService implementation

- Made updateGraph in GraphDBSparqlService independent as required by SparqlService default methods
- Removed private uploadTtl to allow use of default implementation
- Added GraphDB-based implementation for RdfSparqlService
- Added single transaction replaceGraph to both GraphDB implementations

See issue #26 